### PR TITLE
Update the old URL in the docs

### DIFF
--- a/docs/command_line_switches.md
+++ b/docs/command_line_switches.md
@@ -33,9 +33,9 @@
 
 ## Uses In Powershell One Liner
 
-`& ([ScriptBlock]::Create((irm https://mass grave.dev/get))) /para`
+`& ([ScriptBlock]::Create((irm https://get.acti vated.win))) /para`
 
-**Notes** - Remove the space between `mass grave`
+**Notes** - Remove the space between `acti vated`
 
 -   Replace `/para` in this command with the switches from the above table. You can also use multiple switches. For example, `/HWID /KMS-Office /KMS-ActAndRenewalTask`
 -   This Powershell one-liner will work on Windows 8.1 and later versions only.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -18,7 +18,7 @@ A Windows and Office activator using HWID / Ohook / KMS38 / Online KMS activatio
 ```
 irm https://get.activated.win | iex
 ```
-or  
+or (deprecated, will be retired on Aug 31 2024, use above instead)  
 ```
 irm https://massgrave.dev/get | iex
 ```


### PR DESCRIPTION
Hey, just saw that `massgrave.dev/get` will be retired.
It is still mentioned in the docs about the unattended mode.