### PR TITLE
Small fix on PT-BR translation at troubleshoot.md

### DIFF
--- a/docs/troubleshoot.md
+++ b/docs/troubleshoot.md
@@ -10,7 +10,7 @@
 
 ### Читайте и следуйте синим линиям в сценарии.
 
-### Leia e siga as linhas azuis no roteiro.
+### Leia e siga as linhas azuis no script.
 
 :::
 
@@ -25,3 +25,4 @@ import DiscordBadge from '@site/src/components/DiscordBadge';
 <DiscordBadge />
 
 ------------------------------------------------------------------------
+


### PR DESCRIPTION
Small fix on PT-BR translation at troubleshoot.md: "roteiro" means a literal sheet of paper, not a programming script, most of Portuguese programmers uses "script" anyways due to this.